### PR TITLE
chore(mcps/brave-search-npx): update to new format

### DIFF
--- a/mcps/brave-search-npx/metadata.en.yml
+++ b/mcps/brave-search-npx/metadata.en.yml
@@ -1,9 +1,9 @@
 name: "Brave Search (npx)"
 description: "The \"Brave Search\" MCP"
 type: "mcp"
-version: "0.1.0"
-binaryUrl: "https://github.com/NamesMT/config-packs/releases/download/v0.0.0/roo-brave-search-mcp.zip"
-binaryHash: "kN1uFyQS-K4ELyAFMP8orNpxTibQfEOi1v2Hq_d-gNg"
+version: "0.5.0"
+binaryUrl: "https://github.com/NamesMT/config-packs/releases/download/v0.0.0/roo-brave-search-mcp-new.zip"
+binaryHash: "3iZiPaGQ8Zu8NlWQMXce1uqLufIC4fXL16U3DnMmy_Y"
 sourceUrl: "https://github.com/NamesMT/config-packs"
 tags: ["Brave", "MCP"]
 author: "NamesMT"


### PR DESCRIPTION
I made some final breaking changes to the underlying install engine and is updating registry items to the new format.

NOTE!: merge this PR at the same time as this: https://github.com/Smartsheet-JB-Brown/Roo-Code/pull/7
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `metadata.en.yml` for Brave Search MCP to new format with updated version, binary URL, and hash.
> 
>   - **Metadata Update**:
>     - Update `version` to `0.5.0` in `metadata.en.yml`.
>     - Change `binaryUrl` to `roo-brave-search-mcp-new.zip` in `metadata.en.yml`.
>     - Update `binaryHash` to `3iZiPaGQ8Zu8NlWQMXce1uqLufIC4fXL16U3DnMmy_Y` in `metadata.en.yml`.
>   - **Note**:
>     - Merge this PR simultaneously with another related PR.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code-Marketplace&utm_source=github&utm_medium=referral)<sup> for fd5f5704472358b42dfa96ddda93b18f04ed8690. You can [customize](https://app.ellipsis.dev/RooVetGit/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->